### PR TITLE
Add support for Node.js v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "8"
 cache:
   yarn: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,7 +116,7 @@ function link(fs, rewrites) {
             var path = args[0];
             // If first argument is not a path, just proxy the function.
             if ((typeof path !== 'string') && !Buffer.isBuffer(path)) {
-                if (!require('url') || !(path instanceof require('url').URL))
+                if (!require('url').URL || !(path instanceof require('url').URL))
                     return func.apply(fs, args);
             }
             // Rewrite the path argument.

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export function link(fs, rewrites: string[] | string[][]): any {
 
             // If first argument is not a path, just proxy the function.
             if((typeof path !== 'string') && !Buffer.isBuffer(path)) {
-                if(!require('url') || !(path instanceof require('url').URL))
+                if(!require('url').URL || !(path instanceof require('url').URL))
                     return func.apply(fs, args);
             }
 


### PR DESCRIPTION
- require('url').URL constructor is only available since Node.js v8, so test its availability appropriately