### PR TITLE
Fixed rename methods and other multi path functions

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -65,13 +65,9 @@ describe('rewrite(fs, rewrites)', () => {
             '/1/2/3/4': 'foo'
         });
 
-        console.log(vol.toJSON());
-
         const lfs = link(vol, ['/', '/1/2/3']);
 
         lfs.renameSync('/4', '/5');
-
-        console.log(vol.toJSON());
 
         expect(lfs.readFileSync('/5', 'utf8')).toBe('foo');
     })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -59,4 +59,20 @@ describe('rewrite(fs, rewrites)', () => {
 
         expect(lfs.readFileSync('/4', 'utf8')).toBe('foo');
     });
+
+    it('handles file rename', () => {
+        const vol = Volume.fromJSON({
+            '/1/2/3/4': 'foo'
+        });
+
+        console.log(vol.toJSON());
+
+        const lfs = link(vol, ['/', '/1/2/3']);
+
+        lfs.renameSync('/4', '/5');
+
+        console.log(vol.toJSON());
+
+        expect(lfs.readFileSync('/5', 'utf8')).toBe('foo');
+    })
 });


### PR DESCRIPTION
Previously we were only rewriting the first argument of a file system method, despite a few others having two (namely `rename`).

This change rewrites the second argument for methods that are specified to have two arguments.