### PR TITLE
feat: using generic type to avoid lose type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export const proxyableMethods = [
 ];
 
 
-export function link(fs, rewrites: string[] | string[][]): any {
+export function link<T>(fs: T, rewrites: string[] | string[][]): T {
     if(!(rewrites instanceof Array))
         throw TypeError('rewrites must be a list of 2-tuples');
 


### PR DESCRIPTION
```
const lfs = link(fs, ['/foo2', '/foo']);
```
the lfs will be `any` although fs has types, we expect lfs has same type with fs